### PR TITLE
Added rotation behaviour.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ImGui Knobs
-This is a port/adaptation of [imgui-rs-knobs](https://github.com/DGriffin91/imgui-rs-knobs), for C++.
+I have made some changes to [imgui-knobs](https://github.com/altschuler/imgui-knobs), which is a port/adaptation of [imgui-rs-knobs](https://github.com/DGriffin91/imgui-rs-knobs), for C++.
 
 ![image](https://user-images.githubusercontent.com/956928/164050142-96a8dde4-7d2e-43e4-9afe-14ab48eac243.png)
 
@@ -18,7 +18,7 @@ if (ImGuiKnobs::Knob("Volume", &value, -6.0f, 6.0f, 0.1f, "%.1fdB", ImGuiKnobVar
 Draw knobs using either `Knob` or `KnobInt`. The API is:
 
 ```
-bool ImGuiKnobs::Knob(label, *value, min, max, [speed, format, variant, size, flags, steps])
+bool ImGuiKnobs::Knob(label, *value, min, max, [speed, format, variant, size, flags, steps, angle_min, angle_max])
 bool ImGuiKnobs::KnobInt(label, *value, min, max, [speed, format, variant, size, flags, steps])
 ```
 
@@ -30,6 +30,9 @@ bool ImGuiKnobs::KnobInt(label, *value, min, max, [speed, format, variant, size,
  - `ImGuiKnobFlags_NoInput`: Hide the bottom drag input.
  - `ImGuiKnobFlags_ValueTooltip`: Show a tooltip with the current value on hover.
  - `ImGuiKnobFlags_DragHorizontal`: Use horizontal dragging (default is vertical).
+ - `ImGuiKnobFlags_RotateRelative`: Use rotate relative dragging.
+ - `ImGuiKnobFlags_RotateAbsolute`: Use rotate absolute dragging.
+ - `ImGuiKnobFlags_WrapAround`: Values wraparound when using the "rotate" flags.
 
 ### Size
 You can specify a size given as the width of the knob (will be scaled according to ImGui's `FontGlobalScale`). Default (0) will use 4x line height.

--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -101,8 +101,19 @@ namespace ImGuiKnobs {
                 return false;
             }
 
-            bool rotate_behavior(DataType *p_value, DataType v_min, DataType v_max,float speed,bool absolute_rot) {
+            bool rotate_behavior(ImGuiID id,DataType *p_value, DataType v_min, DataType v_max,float speed,bool absolute_rot) {
                 ImGuiIO& imgui_io=ImGui::GetIO();
+
+                ImGuiContext& g = *GImGui;
+                if (g.ActiveId == id) {
+                    if (g.ActiveIdSource == ImGuiInputSource_Mouse && !g.IO.MouseDown[0])
+                        ImGui::ClearActiveID();
+                    else if (g.ActiveIdSource == ImGuiInputSource_Nav && g.NavActivatePressedId == id && !g.ActiveIdIsJustActivated)
+                        ImGui::ClearActiveID();
+                }
+
+                if (g.ActiveId != id)
+                    return false;
 
                 if (absolute_rot) {
                     ImVec2 mouse_pos = imgui_io.MousePos;
@@ -174,11 +185,12 @@ namespace ImGuiKnobs {
                 // Handle dragging
                 ImGui::InvisibleButton(_label, {radius * 2.0f, radius * 2.0f});
                 auto gid = ImGui::GetID(_label);
-                ImGuiSliderFlags drag_flags = 0;
+
                 if((flags & (ImGuiKnobFlags_RotateRelative | ImGuiKnobFlags_RotateAbsolute))) {
-                    value_changed = rotate_behavior(p_value, v_min, v_max, speed, flags == ImGuiKnobFlags_RotateAbsolute);
+                    value_changed = rotate_behavior(gid,p_value, v_min, v_max, speed, flags == ImGuiKnobFlags_RotateAbsolute);
                 }
                 else {
+                    ImGuiSliderFlags drag_flags = 0;
                     if (!(flags & ImGuiKnobFlags_DragHorizontal))
                         drag_flags |= ImGuiSliderFlags_Vertical;
 

--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
 #include <imgui_internal.h>
 
@@ -56,7 +57,7 @@ namespace ImGuiKnobs {
 
             auto *draw_list = ImGui::GetWindowDrawList();
 
-            draw_list->AddBezierCurve(start, arc1, arc2, end, color, thickness, num_segments);
+            draw_list->AddBezierCubic(start, arc1, arc2, end, color, thickness, num_segments);
         }
 
         void draw_arc(ImVec2 center, float radius, float start_angle, float end_angle, float thickness, ImColor color, int num_segments, int bezier_count) {
@@ -108,7 +109,7 @@ namespace ImGuiKnobs {
                 if (g.ActiveId == id) {
                     if (g.ActiveIdSource == ImGuiInputSource_Mouse && !g.IO.MouseDown[0])
                         ImGui::ClearActiveID();
-                    else if (g.ActiveIdSource == ImGuiInputSource_Nav && g.NavActivatePressedId == id && !g.ActiveIdIsJustActivated)
+                    else if ((g.ActiveIdSource == ImGuiInputSource_Keyboard || g.ActiveIdSource == ImGuiInputSource_Gamepad) && g.NavActivatePressedId == id && !g.ActiveIdIsJustActivated)
                         ImGui::ClearActiveID();
                 }
 

--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -189,7 +189,7 @@ namespace ImGuiKnobs {
                 auto gid = ImGui::GetID(_label);
 
                 if((flags & (ImGuiKnobFlags_RotateRelative | ImGuiKnobFlags_RotateAbsolute))) {
-                    value_changed = rotate_behavior(gid,p_value, v_min, v_max, speed, flags == ImGuiKnobFlags_RotateAbsolute);
+                    value_changed = rotate_behavior(gid,p_value, v_min, v_max, speed, flags & ImGuiKnobFlags_RotateAbsolute);
                 }
                 else {
                     ImGuiSliderFlags drag_flags = 0;

--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -177,7 +177,8 @@ namespace ImGuiKnobs {
             }
 
 
-            knob(const char *_label, ImGuiDataType data_type, DataType *p_value, DataType v_min, DataType v_max, float speed, float _radius, const char *format, ImGuiKnobFlags flags) {
+            knob(const char *_label, ImGuiDataType data_type, DataType *p_value, DataType v_min, DataType v_max, float speed, float _radius, const char *format, ImGuiKnobFlags flags
+                 ,float aAngleMin=IMGUIKNOBS_PI*0.75f,float aAngleMax=IMGUIKNOBS_PI*2.25f) {
                 radius = _radius;
                 t = ((float) *p_value - v_min) / (v_max - v_min);
                 auto screen_pos = ImGui::GetCursorScreenPos();
@@ -199,8 +200,8 @@ namespace ImGuiKnobs {
                 }
 
 
-                angle_min = IMGUIKNOBS_PI * 0.75f;
-                angle_max = IMGUIKNOBS_PI * 2.25f;
+                angle_min = aAngleMin;
+                angle_max = aAngleMax;
                 is_active = ImGui::IsItemActive();
                 is_hovered = ImGui::IsItemHovered();
                 angle = angle_min + (angle_max - angle_min) * t;
@@ -258,7 +259,8 @@ namespace ImGuiKnobs {
         };
 
         template<typename DataType>
-        knob<DataType> knob_with_drag(const char *label, ImGuiDataType data_type, DataType *p_value, DataType v_min, DataType v_max, float _speed, const char *format, float size, ImGuiKnobFlags flags) {
+        knob<DataType> knob_with_drag(const char *label, ImGuiDataType data_type, DataType *p_value, DataType v_min, DataType v_max, float _speed, const char *format, float size, ImGuiKnobFlags flags
+                                      ,float aAngleMin=IMGUIKNOBS_PI*0.75f,float aAngleMax=IMGUIKNOBS_PI*2.25f) {
             auto speed = _speed == 0 ? (v_max - v_min) / 250.f : _speed;
             ImGui::PushID(label);
             auto width = size == 0 ? ImGui::GetTextLineHeight() * 4.0f : size * ImGui::GetIO().FontGlobalScale;
@@ -281,7 +283,8 @@ namespace ImGuiKnobs {
             }
 
             // Draw knob
-            knob<DataType> k(label, data_type, p_value, v_min, v_max, speed, width * 0.5f, format, flags);
+            knob<DataType> k(label, data_type, p_value, v_min, v_max, speed, width * 0.5f, format, flags
+                             ,aAngleMin,aAngleMax);
 
             // Draw tooltip
             if (flags & ImGuiKnobFlags_ValueTooltip && (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) || ImGui::IsItemActive())) {
@@ -341,8 +344,9 @@ namespace ImGuiKnobs {
 
 
     template<typename DataType>
-    bool BaseKnob(const char *label, ImGuiDataType data_type, DataType *p_value, DataType v_min, DataType v_max, float speed, const char *format, ImGuiKnobVariant variant, float size, ImGuiKnobFlags flags, int steps = 10) {
-        auto knob = detail::knob_with_drag(label, data_type, p_value, v_min, v_max, speed, format, size, flags);
+    bool BaseKnob(const char *label, ImGuiDataType data_type, DataType *p_value, DataType v_min, DataType v_max, float speed, const char *format, ImGuiKnobVariant variant, float size, ImGuiKnobFlags flags, int steps = 10
+                  ,float aAngleMin=IMGUIKNOBS_PI*0.75f,float aAngleMax=IMGUIKNOBS_PI*2.25f) {
+        auto knob = detail::knob_with_drag(label, data_type, p_value, v_min, v_max, speed, format, size, flags,aAngleMin,aAngleMax);
 
         switch (variant) {
             case ImGuiKnobVariant_Tick: {
@@ -405,9 +409,10 @@ namespace ImGuiKnobs {
         return knob.value_changed;
     }
 
-    bool Knob(const char *label, float *p_value, float v_min, float v_max, float speed, const char *format, ImGuiKnobVariant variant, float size, ImGuiKnobFlags flags, int steps) {
+    bool Knob(const char *label, float *p_value, float v_min, float v_max, float speed, const char *format, ImGuiKnobVariant variant, float size, ImGuiKnobFlags flags, int steps
+              ,float aAngleMin,float aAngleMax) {
         const char *_format = format == NULL ? "%.3f" : format;
-        return BaseKnob(label, ImGuiDataType_Float, p_value, v_min, v_max, speed, _format, variant, size, flags, steps);
+        return BaseKnob(label,ImGuiDataType_Float,p_value,v_min,v_max,speed,_format,variant,size,flags,steps,aAngleMin,aAngleMax);
     }
 
     bool KnobInt(const char *label, int *p_value, int v_min, int v_max, float speed, const char *format, ImGuiKnobVariant variant, float size, ImGuiKnobFlags flags, int steps) {

--- a/imgui-knobs.h
+++ b/imgui-knobs.h
@@ -44,6 +44,7 @@ namespace ImGuiKnobs {
         }
     };
 
-    bool Knob(const char *label, float *p_value, float v_min, float v_max, float speed = 0, const char *format = NULL, ImGuiKnobVariant variant = ImGuiKnobVariant_Tick, float size = 0, ImGuiKnobFlags flags = 0, int steps = 10);
+    bool Knob(const char *label, float *p_value, float v_min, float v_max, float speed = 0, const char *format = NULL, ImGuiKnobVariant variant = ImGuiKnobVariant_Tick, float size = 0, ImGuiKnobFlags flags = 0, int steps = 10
+              ,float aAngleMin=3.14159265358979323846f*0.75f,float aAngleMax=3.14159265358979323846f*2.25f);
     bool KnobInt(const char *label, int *p_value, int v_min, int v_max, float speed = 0, const char *format = NULL, ImGuiKnobVariant variant = ImGuiKnobVariant_Tick, float size = 0, ImGuiKnobFlags flags = 0, int steps = 10);
 }// namespace ImGuiKnobs

--- a/imgui-knobs.h
+++ b/imgui-knobs.h
@@ -14,6 +14,7 @@ enum ImGuiKnobFlags_ {
     ImGuiKnobFlags_DragHorizontal = 1 << 3,
     ImGuiKnobFlags_RotateRelative = 1 << 4,
     ImGuiKnobFlags_RotateAbsolute = 1 << 5,
+    ImGuiKnobFlags_WrapAround = 1 << 6,
 };
 
 typedef int ImGuiKnobVariant;

--- a/imgui-knobs.h
+++ b/imgui-knobs.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdlib>
+
+#define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
 
 typedef int ImGuiKnobFlags;

--- a/imgui-knobs.h
+++ b/imgui-knobs.h
@@ -10,6 +10,8 @@ enum ImGuiKnobFlags_ {
     ImGuiKnobFlags_NoInput = 1 << 1,
     ImGuiKnobFlags_ValueTooltip = 1 << 2,
     ImGuiKnobFlags_DragHorizontal = 1 << 3,
+    ImGuiKnobFlags_RotateRelative = 1 << 4,
+    ImGuiKnobFlags_RotateAbsolute = 1 << 5,
 };
 
 typedef int ImGuiKnobVariant;


### PR DESCRIPTION

Added two new flags:
* ImGuiKnobFlags_RotateRelative 
* ImGuiKnobFlags_RotateAbsolute

 With them you have to move around the knob in a circular way. Keyboard input is not currently implemented for these modes.

I attach a video of the relative mode.

![RotateKnob](https://user-images.githubusercontent.com/8093144/202917282-337c7e01-efa9-40d6-b925-3e8657e9f511.gif)
