### PR TITLE
Fix dear imgui compilation breakage

### DIFF
--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -32,8 +32,11 @@ namespace ImGuiKnobs {
             auto arc2 = ImVec2{center[0] + bx + k2 * by, center[1] + by - k2 * bx};
 
             auto *draw_list = ImGui::GetWindowDrawList();
-
+#if IMGUI_VERSION_NUM <= 18000
             draw_list->AddBezierCurve(start, arc1, arc2, end, color, thickness, num_segments);
+#else
+            draw_list->AddBezierCubic(start, arc1, arc2, end, color, thickness, num_segments);
+#endif
         }
 
         void draw_arc(ImVec2 center, float radius, float start_angle, float end_angle, float thickness, ImColor color, int num_segments, int bezier_count) {


### PR DESCRIPTION
Related to #12, this PR fixes the breakage introduced by [dear imgui v1.89.4](https://github.com/ocornut/imgui/releases/tag/v1.89.4)

For imgui versions that are less than or equal to 1.80.0, `AddBezierCurve` is used, for anything newer the new `AddBezierCubic` is used instead. Using less or equal because if the user is using development builds of 1.80.0 it might be problematic and might cause compilation issues.

Tested locally with latest dear imgui version