### PR TITLE
Added setters to specify start and end angles of knobs

### DIFF
--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -8,6 +8,29 @@
 #define IMGUIKNOBS_PI 3.14159265358979323846f
 
 namespace ImGuiKnobs {
+    struct ImGuiKnobsContext
+    {
+        bool set = false;
+        float start_angle = 0.75f;
+        float end_angle = 2.25f;
+    };
+
+    static ImGuiKnobsContext imGuiKnobsContext;
+
+    void SetStartAndEndAngle(float start_angle, float end_angle)
+    {
+        imGuiKnobsContext.set = true;
+        imGuiKnobsContext.start_angle = start_angle;
+        imGuiKnobsContext.end_angle = end_angle;
+    }
+
+    void SetStartAndEndAngleDeg(float start_angle, float end_angle)
+    {
+        imGuiKnobsContext.set = true;
+        imGuiKnobsContext.start_angle = start_angle * (1.0f / 180.0f);
+        imGuiKnobsContext.end_angle = end_angle * (1.0f / 180.0f);
+    }
+
     namespace detail {
         void draw_arc1(ImVec2 center, float radius, float start_angle, float end_angle, float thickness, ImColor color, int num_segments) {
             ImVec2 start = {
@@ -83,8 +106,18 @@ namespace ImGuiKnobs {
                 }
                 value_changed = ImGui::DragBehavior(gid, data_type, p_value, speed, &v_min, &v_max, format, drag_flags);
 
-                angle_min = IMGUIKNOBS_PI * 0.75f;
-                angle_max = IMGUIKNOBS_PI * 2.25f;
+                if (!imGuiKnobsContext.set)
+                {
+                    angle_min = IMGUIKNOBS_PI * 0.75f;
+                    angle_max = IMGUIKNOBS_PI * 2.25f;
+                }
+                else
+                {
+                    imGuiKnobsContext.set = false;
+                    angle_min = IMGUIKNOBS_PI * imGuiKnobsContext.start_angle;
+                    angle_max = IMGUIKNOBS_PI * imGuiKnobsContext.end_angle;
+                }
+
                 center = {screen_pos[0] + radius, screen_pos[1] + radius};
                 is_active = ImGui::IsItemActive();
                 is_hovered = ImGui::IsItemHovered();

--- a/imgui-knobs.h
+++ b/imgui-knobs.h
@@ -40,6 +40,9 @@ namespace ImGuiKnobs {
         }
     };
 
+    void SetStartAndEndAngle(float start_angle, float end_angle);
+    void SetStartAndEndAngleDeg(float start_angle, float end_angle);
+
     bool Knob(const char *label, float *p_value, float v_min, float v_max, float speed = 0, const char *format = NULL, ImGuiKnobVariant variant = ImGuiKnobVariant_Tick, float size = 0, ImGuiKnobFlags flags = 0, int steps = 10);
     bool KnobInt(const char *label, int *p_value, int v_min, int v_max, float speed = 0, const char *format = NULL, ImGuiKnobVariant variant = ImGuiKnobVariant_Tick, float size = 0, ImGuiKnobFlags flags = 0, int steps = 10);
 }// namespace ImGuiKnobs


### PR DESCRIPTION
Added setters (and related context) to specify start and end angles of knobs (the original interface is still usable)  
![anglerangeknob](https://github.com/altschuler/imgui-knobs/assets/58108277/d8ecd9fb-7368-4b13-bbfc-8f97ca3a60c5)
