### PR TITLE
Fix font scaling compilation errors with the new dear imgui 1.92

### DIFF
--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -162,7 +162,13 @@ namespace ImGuiKnobs {
 
             auto speed = _speed == 0 ? (v_max - v_min) / 250.f : _speed;
             ImGui::PushID(label);
-            auto width = size == 0 ? ImGui::GetTextLineHeight() * 4.0f : size * ImGui::GetIO().FontGlobalScale;
+
+#if IMGUI_VERSION_NUM < 19197
+            auto font_scale = ImGui::GetIO().FontGlobalScale;
+#else
+            auto font_scale = ImGui::GetStyle().FontScaleMain;
+#endif
+            auto width = size == 0 ? ImGui::GetTextLineHeight() * 4.0f : size * font_scale;
             ImGui::PushItemWidth(width);
 
             ImGui::BeginGroup();


### PR DESCRIPTION
With the coming 1.92 release of dear imgui, a major change in the way fonts are handled was introduced. There are many breaking changes already. Most of the features have already made it into master and I encountered a small compilation error after updating.

With revision `19197`, `io.FontGlobalScale` got moved to `style.FontScaleMain`. I added support for both the new and old APIs with a preprocessor check.

Tested locally with the latest commit and `19196`