### PR TITLE
fix for imgui v1.92.8

### DIFF
--- a/imgui-knobs.cpp
+++ b/imgui-knobs.cpp
@@ -15,7 +15,11 @@ namespace ImGuiKnobs {
             auto *draw_list = ImGui::GetWindowDrawList();
 
             draw_list->PathArcTo(center, radius, start_angle, end_angle);
+#if IMGUI_VERSION_NUM < 19276
             draw_list->PathStroke(color, 0, thickness);
+#else
+            draw_list->PathStroke(color,thickness);
+#endif
         }
 
         template<typename DataType>


### PR DESCRIPTION
See https://github.com/ocornut/imgui/releases/tag/v1.92.8

This is a fix for a breaking change: "DrawList: swapped the last two arguments of AddRect(), AddPolyline(), PathStroke()."

